### PR TITLE
Bump asreview version, increase upload size, fixe project volume

### DIFF
--- a/asreview.conf
+++ b/asreview.conf
@@ -3,7 +3,7 @@ events {
 }
 
 http {
-  client_max_body_size      75M;
+  client_max_body_size      100M;
   proxy_cache_path          /var/cache/nginx/asreview keys_zone=asreview:20m max_size=500m;
 
   upstream asreview_container {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,12 @@ services:
       - database-volume:/var/lib/postgresql/data
 
   asreview:
-    image: "ghcr.io/asreview/asreview:v1.6.1"
+    image: "ghcr.io/asreview/asreview:v1.6.2"
     depends_on:
       database:
         condition: service_healthy
     volumes:
-      - project-folder:/app/project_folder
+      - project-folder:/project_folder
       - ./asreview_config.toml:/app/asreview_config.toml
     environment:
       - ASREVIEW_LAB_API_URL=/


### PR DESCRIPTION
Bumping ASReview from 1.6.1 to 1.6.2 is already done in another PR, sorry about that. In the Nginx config file the upload file size is increased to 100M because a user had to import a bigger file than 75M. 
The most important fix is the project volume in the compose file. The project folder is located in the root directory, not in the /app directory.